### PR TITLE
link to reset password

### DIFF
--- a/bloodbank/templates/auth/login.html
+++ b/bloodbank/templates/auth/login.html
@@ -27,5 +27,9 @@
     <br>
     <br>
     <br>
+    <a href="#" class="card-link">Reset Password</a>
+    <br>
+    <br>
+    <br>
   </form>
 {% endblock %}


### PR DESCRIPTION
added a link to the end of the auth/login.py page to reset the password. The link is not working.